### PR TITLE
feat: add use click outside hook

### DIFF
--- a/src/hooks/use-click-outside.ts
+++ b/src/hooks/use-click-outside.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Custom hook to detect clicks outside a specified element and manage open state.
+ *
+ * @template T - The type of the element to detect clicks outside of. Defaults to `HTMLElement`.
+ * @param {() => void} onClickOutside - Function to call when a click outside the specified element is detected.
+ * @returns {[boolean, () => void, React.RefObject<T>]} An array containing:
+ * - `isOpen`: Boolean indicating if the element is open.
+ * - `toggleOpen`: Function to toggle the open state.
+ * - `elementRef`: A ref object to attach to the element you want to detect clicks outside of.
+ *
+ * @example
+ * const [isOpen, toggleOpen, ref] = useClickOutside(() => {
+ *   console.log('Clicked outside!');
+ * });
+ */
+function useClickOutside<T extends HTMLElement = HTMLElement>(
+  callback?: () => void
+) {
+  const [isOpen, setIsOpen] = useState(false);
+  const elementRef = useRef<T>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        buttonRef.current &&
+        buttonRef.current.contains(event.target as Node)
+      ) {
+        return;
+      }
+      if (
+        elementRef.current &&
+        !elementRef.current.contains(event.target as Node)
+      ) {
+        if (callback) callback();
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [callback]);
+
+  const toggleOpen = () => {
+    setIsOpen((prevState) => !prevState);
+  };
+
+  return [isOpen, toggleOpen, elementRef, buttonRef] as const;
+}
+
+export default useClickOutside;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export { default as useClickOutside } from './hooks/use-click-outside';
 export { default as useScrollPosition } from './hooks/use-scroll-position';


### PR DESCRIPTION
### Description
This pull request introduces improvements to the `useClickOutside` custom hook by integrating the state management for the dropdown's open/close state within the hook itself. The enhancements ensure better encapsulation and separation of concerns, making the hook more reusable and the consuming component cleaner and simpler.