### PR TITLE
Add useListenToEvent Custom Hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oceandev-hooks",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A collection of custom React hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/hooks/use-listen-to-event.ts
+++ b/src/hooks/use-listen-to-event.ts
@@ -1,0 +1,54 @@
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Custom hook to manage event listening on one or multiple DOM elements.
+ *
+ * @param {RefObject<T> | RefObject<T>[]} refOrRefs - A single ref or an array of refs to track.
+ * @param {keyof HTMLElementEventMap} event - The event type to listen for (e.g., 'click', 'scroll').
+ * @param {(ev: HTMLElementEventMap[keyof HTMLElementEventMap]) => void} callback - The callback function to execute when the event occurs.
+ *
+ * @example
+ * // Single ref usage
+ * useListenToEvent<HTMLDivElement>(
+ *   divRef,
+ *   'click',
+ *   (e) => {
+ *     console.log(e);
+ *   }
+ * );
+ *
+ * @example
+ * // Multiple refs usage
+ * useListenToEvent<HTMLDivElement | HTMLAnchorElement>(
+ *   [div1Ref, div2Ref],
+ *   'click',
+ *   (e) => {
+ *     console.log(e);
+ *   }
+ * );
+ */
+function useListenToEvent<T extends HTMLElement = HTMLElement>(
+  refOrRefs: RefObject<T> | RefObject<T>[],
+  event: keyof HTMLElementEventMap,
+  callback: (ev: HTMLElementEventMap[keyof HTMLElementEventMap]) => void
+) {
+  useEffect(() => {
+    const refArray = Array.isArray(refOrRefs) ? refOrRefs : [refOrRefs];
+
+    refArray.forEach((ref) => {
+      if (ref.current) {
+        ref.current.addEventListener(event, callback);
+      }
+    });
+
+    return () => {
+      refArray.forEach((ref) => {
+        if (ref.current) {
+          ref.current.removeEventListener(event, callback);
+        }
+      });
+    };
+  }, [refOrRefs, event, callback]);
+}
+
+export default useListenToEvent;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { default as useClickOutside } from './hooks/use-click-outside';
 export { default as useCookie } from './hooks/use-cookie';
 export { default as useLocalStorage } from './hooks/use-local-storage';
 export { default as useScrollPosition } from './hooks/use-scroll-position';
+export { default as useListenToEvent } from './hooks/use-listen-to-event';


### PR DESCRIPTION
### PR Description: Add `useListenToEvent` Custom Hook

#### Summary

This PR introduces a new custom React hook, `useListenToEvent`, designed to manage event listeners for multiple DOM elements using refs. The hook simplifies the process of adding and removing event listeners, ensuring a clean and efficient way to handle events on various elements.

#### Features

- Multi-element Event Listening: Add event listeners to multiple elements using an array of refs.
- Dynamic Event Type: Easily specify different event types (`click`, `dblclick`, `mouseover`, etc.) through a parameter.
- Callback Handling: Provide a custom callback function to handle the event.

#### API

```typescript
import { RefObject, useEffect } from 'react';

/**
 * Custom hook to manage event listening to different node elements at once.
 *
 * @param {RefObject<T> | RefObject<T>[]} refs - A ref or an array of refs to track.
 * @param {keyof HTMLElementEventMap} event - Event type: click, dblclick, mouseover, etc.
 * @param {(ev: HTMLElementEventMap[keyof HTMLElementEventMap]) => void} callback - Callback function to handle the event.
 * @example
 * ```
 * useListenToEvent<HTMLDivElement | HTMLAnchorElement>(
 *   [div1Ref, div2Ref],
 *   'click',
 *   (e) => {
 *     console.log(e);
 *   }
 * );
 * ```
 */
function useListenToEvent<T extends HTMLElement = HTMLElement>(
  refs: RefObject<T> | RefObject<T>[],
  event: keyof HTMLElementEventMap,
  callback: (ev: HTMLElementEventMap[keyof HTMLElementEventMap]) => void
) {
  useEffect(() => {
    const elements = Array.isArray(refs) ? refs : [refs];

    elements.forEach((ref) => {
      if (ref.current) ref.current.addEventListener(event, callback);
    });

    return () => {
      elements.forEach((ref) => {
        if (ref.current) ref.current.removeEventListener(event, callback);
      });
    };
  }, [refs, event, callback]);
}

export default useListenToEvent;
