### PR TITLE
use-listen-event hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,176 @@ A collection of custom React hooks.
 
 ```sh
 npm install oceandev-hooks
+```
+# Example of Usage
+
+## `useScrollPosition`:
+
+Here's an example of how to use the `useScrollPosition` hook in a React component.
+
+```jsx
+import React, { useRef } from 'react';
+import { useScrollPosition } from 'oceandev-hooks';
+
+function ScrollableComponent() {
+  // Use the custom hook
+  const [scrollPosition, scrollContainerRef, scrollTo, isAtBottom] = useScrollPosition();
+
+  const handleScrollToTop = () => {
+    scrollTo({ direction: 'top' });
+  };
+
+  const handleScrollToBottom = () => {
+    scrollTo({ direction: 'bottom' });
+  };
+
+  return (
+    <div ref={scrollContainerRef} style={{ height: '300px', overflowY: 'auto' }}>
+      {/* Render your scrollable content here */}
+      <div style={{ height: '1000px' }}>Scrollable Content</div>
+
+      {/* Display scroll position */}
+      <p>Scroll Position: {scrollPosition.y}</p>
+
+      {/* Buttons to scroll to top and bottom */}
+      <button onClick={handleScrollToTop}>Scroll to Top</button>
+      <button onClick={handleScrollToBottom}>Scroll to Bottom</button>
+
+      {/* Display if at bottom */}
+      <p>{isAtBottom ? 'At Bottom' : 'Not at Bottom'}</p>
+    </div>
+  );
+}
+
+export default ScrollableComponent;
+```
+## `useClickOutside`:
+
+Here's an example of how to use the `useClickOutside` hook in a React component.
+
+```jsx
+import React from 'react';
+import useClickOutside from './useClickOutside';
+
+function Dropdown() {
+  // Use the custom hook
+  const [isOpen, toggleOpen, elementRef, buttonRef] = useClickOutside(() => {
+    console.log('Clicked outside!');
+  });
+
+  return (
+    <div>
+      <button ref={buttonRef} onClick={toggleOpen}>
+        Toggle Dropdown
+      </button>
+      {isOpen && (
+        <div ref={elementRef} style={{ border: '1px solid black', padding: '10px' }}>
+          Dropdown Content
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Dropdown;
+```
+## `useCookie`
+Here's an example of how to use the `useCookie` hook in a React component.
+
+```jsx
+import React, { useState } from 'react';
+import useCookie from './useCookie';
+
+function CookieComponent() {
+  // Use the custom hook
+  const [setCookie, getCookie, getCookies, deleteCookie] = useCookie('myCookie');
+
+  const [inputValue, setInputValue] = useState('');
+
+  const handleSave = () => {
+    setCookie(inputValue);
+  };
+
+  const handleLoad = () => {
+    const storedValue = getCookie();
+    alert('Stored value: ' + storedValue);
+  };
+
+  const handleShowAll = () => {
+    const allCookies = getCookies();
+    console.log('All cookies:', allCookies);
+  };
+
+  const handleDelete = () => {
+    deleteCookie();
+    alert('Cookie deleted');
+  };
+
+  return (
+    <div>
+      <h1>useCookie Hook Example</h1>
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+      />
+      <button onClick={handleSave}>Save to Cookie</button>
+      <button onClick={handleLoad}>Load from Cookie</button>
+      <button onClick={handleShowAll}>Show all Cookies</button>
+      <button onClick={handleDelete}>Delete Cookie</button>
+    </div>
+  );
+}
+
+export default CookieComponent;
+```
+## `useLocalStorage`
+
+Here's an example of how to use the `useLocalStorage` hook in a React component.
+
+```jsx
+import React, { useState } from 'react';
+import useLocalStorage from './useLocalStorage';
+
+function LocalStorageComponent() {
+  // Use the custom hook
+  const [setItem, getItem, getItems, deleteItem] = useLocalStorage('myKey');
+
+  const [inputValue, setInputValue] = useState('');
+
+  const handleSave = () => {
+    setItem(inputValue);
+  };
+
+  const handleLoad = () => {
+    const storedValue = getItem();
+    alert('Stored value: ' + storedValue);
+  };
+
+  const handleShowAll = () => {
+    const allItems = getItems();
+    console.log('All localStorage items:', allItems);
+  };
+
+  const handleDelete = () => {
+    deleteItem();
+    alert('Item deleted');
+  };
+
+  return (
+    <div>
+      <h1>useLocalStorage Hook Example</h1>
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+      />
+      <button onClick={handleSave}>Save to localStorage</button>
+      <button onClick={handleLoad}>Load from localStorage</button>
+      <button onClick={handleShowAll}>Show all localStorage items</button>
+      <button onClick={handleDelete}>Delete Item from localStorage</button>
+    </div>
+  );
+}
+
+export default LocalStorageComponent;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oceandev-hooks",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A collection of custom React hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/hooks/use-listen-to-event.ts
+++ b/src/hooks/use-listen-to-event.ts
@@ -1,0 +1,54 @@
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Custom hook to manage event listening on one or multiple DOM elements.
+ *
+ * @param {RefObject<T> | RefObject<T>[]} refOrRefs - A single ref or an array of refs to track.
+ * @param {keyof HTMLElementEventMap} event - The event type to listen for (e.g., 'click', 'scroll').
+ * @param {(ev: HTMLElementEventMap[keyof HTMLElementEventMap]) => void} callback - The callback function to execute when the event occurs.
+ *
+ * @example
+ * // Single ref usage
+ * useListenToEvent<HTMLDivElement>(
+ *   divRef,
+ *   'click',
+ *   (e) => {
+ *     console.log(e);
+ *   }
+ * );
+ *
+ * @example
+ * // Multiple refs usage
+ * useListenToEvent<HTMLDivElement | HTMLAnchorElement>(
+ *   [div1Ref, div2Ref],
+ *   'click',
+ *   (e) => {
+ *     console.log(e);
+ *   }
+ * );
+ */
+function useListenToEvent<T extends HTMLElement = HTMLElement>(
+  refOrRefs: RefObject<T> | RefObject<T>[],
+  event: keyof HTMLElementEventMap,
+  callback: (ev: HTMLElementEventMap[keyof HTMLElementEventMap]) => void
+) {
+  useEffect(() => {
+    const refArray = Array.isArray(refOrRefs) ? refOrRefs : [refOrRefs];
+
+    refArray.forEach((ref) => {
+      if (ref.current) {
+        ref.current.addEventListener(event, callback);
+      }
+    });
+
+    return () => {
+      refArray.forEach((ref) => {
+        if (ref.current) {
+          ref.current.removeEventListener(event, callback);
+        }
+      });
+    };
+  }, [refOrRefs, event, callback]);
+}
+
+export default useListenToEvent;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { default as useClickOutside } from './hooks/use-click-outside';
 export { default as useCookie } from './hooks/use-cookie';
 export { default as useLocalStorage } from './hooks/use-local-storage';
 export { default as useScrollPosition } from './hooks/use-scroll-position';
+export { default as useListenToEvent } from './hooks/use-listen-to-event';


### PR DESCRIPTION
### PR Description: Add `useListenToEvent` Custom Hook

#### Summary

This PR introduces a new custom React hook, `useListenToEvent`, designed to manage event listeners for multiple DOM elements using refs. The hook simplifies the process of adding and removing event listeners, ensuring a clean and efficient way to handle events on various elements.

#### Features

- Multi-element Event Listening: Add event listeners to multiple elements using an array of refs.
- Dynamic Event Type: Easily specify different event types (`click`, `dblclick`, `mouseover`, etc.) through a parameter.
- Callback Handling: Provide a custom callback function to handle the event.

#### API

```typescript
import { RefObject, useEffect } from 'react';

/**
 * Custom hook to manage event listening to different node elements at once.
 *
 * @param {RefObject<T> | RefObject<T>[]} refs - A ref or an array of refs to track.
 * @param {keyof HTMLElementEventMap} event - Event type: click, dblclick, mouseover, etc.
 * @param {(ev: HTMLElementEventMap[keyof HTMLElementEventMap]) => void} callback - Callback function to handle the event.
 * @example
 * ```
 * useListenToEvent<HTMLDivElement | HTMLAnchorElement>(
 *   [div1Ref, div2Ref],
 *   'click',
 *   (e) => {
 *     console.log(e);
 *   }
 * );
 * ```
 */
function useListenToEvent<T extends HTMLElement = HTMLElement>(
  refs: RefObject<T> | RefObject<T>[],
  event: keyof HTMLElementEventMap,
  callback: (ev: HTMLElementEventMap[keyof HTMLElementEventMap]) => void
) {
  useEffect(() => {
    const elements = Array.isArray(refs) ? refs : [refs];

    elements.forEach((ref) => {
      if (ref.current) ref.current.addEventListener(event, callback);
    });

    return () => {
      elements.forEach((ref) => {
        if (ref.current) ref.current.removeEventListener(event, callback);
      });
    };
  }, [refs, event, callback]);
}

export default useListenToEvent;
